### PR TITLE
feat: adição do filtro de beetwen

### DIFF
--- a/src/core/blueprints/exportacoes.py
+++ b/src/core/blueprints/exportacoes.py
@@ -153,6 +153,18 @@ def vias_utilizadas():
     args = vias_utilizadas_args.parse_args(strict=True)
     db = SQLAlchemy.get_instance()
 
+    # Condição do periodo
+    filters = [ ExportacaoModel.uf_id == args["uf_id"] ]
+    ano_inicial = args.get("periodo_ano_inicial")
+    ano_final = args["periodo_ano_final"]
+
+    if ano_inicial is not None:
+        # Se o ano inicial for fornecido, filtramos no período [ano_inicial, ano_final]
+        filters.append(ExportacaoModel.ano.between(ano_inicial, ano_final))
+    else:
+        # Se o ano inicial não for fornecido, filtramos apenas pelo ano final
+        filters.append(ExportacaoModel.ano == ano_final)
+
     base_query = (
         db.session.query(
             func.count(ExportacaoModel.via_id).label("qtd"),
@@ -160,10 +172,7 @@ def vias_utilizadas():
         )
         .select_from(ExportacaoModel)
         .join(ViaModel, ExportacaoModel.via_id == ViaModel.id)
-        .filter(
-            ExportacaoModel.ano == args["ano"],
-            ExportacaoModel.uf_id == args["uf_id"]
-            )
+        .filter(*filters)
         .group_by(ExportacaoModel.via_id)
         .order_by(desc("qtd"))
     )
@@ -181,13 +190,25 @@ def urfs_utilizadas():
     args = urf_utilizadas_args.parse_args(strict=True)
 
     db = SQLAlchemy.get_instance()
+    
+    # Condição do periodo
+    filters = [ ExportacaoModel.uf_id == args["uf_id"] ]
+    ano_inicial = args.get("periodo_ano_inicial")
+    ano_final = args["periodo_ano_final"]
+    
+    if ano_inicial is not None:
+        # Se o ano inicial for fornecido, filtramos no período [ano_inicial, ano_final]
+        filters.append(ExportacaoModel.ano.between(ano_inicial, ano_final))
+    else:
+        # Se o ano inicial não for fornecido, filtramos apenas pelo ano final
+        filters.append(ExportacaoModel.ano == ano_final)
 
     entries = (
         db.session.query(
             ExportacaoModel.urf_id.label("urf_id"),
             db.func.count(ExportacaoModel.urf_id).label("qtd")
         )
-        .filter(ExportacaoModel.ano == args["ano"],ExportacaoModel.uf_id == args["uf_id"])
+        .filter(*filters)
         .group_by(ExportacaoModel.urf_id)
         .all()
     )

--- a/src/core/blueprints/importacoes.py
+++ b/src/core/blueprints/importacoes.py
@@ -150,6 +150,17 @@ def vias_utilizadas():
     args = vias_utilizadas_args.parse_args(strict=True)
 
     db = SQLAlchemy.get_instance()
+    # Condição do periodo
+    filters = [ ImportacaoModel.uf_id == args["uf_id"] ]
+    ano_inicial = args.get("periodo_ano_inicial")
+    ano_final = args["periodo_ano_final"]
+    if ano_inicial is not None:
+        # Se o ano inicial for fornecido, filtramos no período [ano_inicial, ano_final]
+        filters.append(ImportacaoModel.ano.between(ano_inicial, ano_final))
+    else:
+        # Se o ano inicial não for fornecido, filtramos apenas pelo ano final
+        filters.append(ImportacaoModel.ano == ano_final)
+
 
     entries = (
         db.session.query(
@@ -157,7 +168,7 @@ def vias_utilizadas():
             ImportacaoModel.via_id.label("via_id")
         )
         .join(ViaModel, ImportacaoModel.via_id == ViaModel.id)
-        .filter(ImportacaoModel.ano == args["ano"], ImportacaoModel.uf_id == args["uf_id"])
+        .filter(*filters)
         .group_by(ImportacaoModel.via_id)
         .all()
     )
@@ -174,16 +185,23 @@ def urfs_utilizadas():
     args = urf_utilizadas_args.parse_args(strict=True)
 
     db = SQLAlchemy.get_instance()
+    # Condição do periodo
+    filters = [ ImportacaoModel.uf_id == args["uf_id"] ]
+    ano_inicial = args.get("periodo_ano_inicial")
+    ano_final = args["periodo_ano_final"]
+    if ano_inicial is not None:
+        # Se o ano inicial for fornecido, filtramos no período [ano_inicial, ano_final]
+        filters.append(ImportacaoModel.ano.between(ano_inicial, ano_final))
+    else:
+        # Se o ano inicial não for fornecido, filtramos apenas pelo ano final
+        filters.append(ImportacaoModel.ano == ano_final)
 
     entries = (
         db.session.query(
             ImportacaoModel.urf_id.label("urf_id"),
             db.func.count(ImportacaoModel.urf_id).label("qtd")
         )
-        .filter(
-            ImportacaoModel.ano == args["ano"],
-            ImportacaoModel.uf_id == args["uf_id"]
-        )
+        .filter(*filters)
         .group_by(ImportacaoModel.urf_id)
         .all()
     )

--- a/src/core/request.py
+++ b/src/core/request.py
@@ -32,11 +32,13 @@ cargas_movimentadas_args.add_argument("cursor", type=int, required=False, defaul
 """
 # Vias utilizadas
 vias_utilizadas_args = reqparse.RequestParser()
-vias_utilizadas_args.add_argument("ano", type=int, required=True, help="Um ano deve ser informado.")
+vias_utilizadas_args.add_argument("periodo_ano_final", type=int, required=True, help="Ano para ser feito o calculo de periodo")
+vias_utilizadas_args.add_argument("periodo_ano_inicial", type=int, required=False, help="Um ano deve ser informado.")
 vias_utilizadas_args.add_argument("uf_id", type=int, required=True, help="ID da UF inválido.")
 # Urf utilizadas
 urf_utilizadas_args = reqparse.RequestParser()
-urf_utilizadas_args.add_argument("ano",  type=int,  required=True,  help="Um ano deve ser informado.")
+urf_utilizadas_args.add_argument("periodo_ano_final",  type=int,  required=True,    help="Ano para ser feito o calculo de periodo")
+urf_utilizadas_args.add_argument("periodo_ano_inicial",  type=int,  required=False,  help="Ano inicial do periodo, se não for passado, apenas pegara o ano normal.")
 urf_utilizadas_args.add_argument("uf_id", type=int,  required=True, help="ID da UF inválido.")
 """
     Argumentos para valor [ Balança Comercial ]


### PR DESCRIPTION
front-end: https://github.com/Bug-Busters-F/alfalog-frontend/tree/feat/periodo-ano

Essa task foi feita para atender o requisito do front-end para a task de periodo de ano.
as rotas alteradas foram `urfs-utilizadas` e `vias-utilizadas` tanto de IMPORTAÇÃO quanto de EXPORTAÇÃO.
agora o body da requisição está assim em ambas as query.
```
{
    "periodo_ano_final": 2016,
    "periodo_ano_inicial": 2014,
    "uf_id": 20
}
```